### PR TITLE
Improve dkim validation

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,6 +1,7 @@
+name             "opendkim"
 maintainer       "Jeremiah Snapp"
 maintainer_email "jeremiah.snapp@gmail.com"
 license          "Apache 2.0"
 description      "Installs/Configures opendkim"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.0.1"
+version          "0.0.2"

--- a/templates/default/opendkim.conf.erb
+++ b/templates/default/opendkim.conf.erb
@@ -28,3 +28,8 @@ SubDomains <%= node['opendkim']['subdomains'] %>
 #Mode     sv
 #SubDomains   no
 #ADSPDiscard    no
+
+Canonicalization relaxed/relaxed
+OversignHeaders From,Subject,To
+SignHeaders *,+Message-ID,+MIME-Version,+Content-Type
+


### PR DESCRIPTION
Improve security of e-mails and compatibility.
Yahoo, Gmail and Outlook also use "c=relaxed/relaxed".
https://wordtothewise.com/2016/12/dkim-canonicalization-or-why-microsoft-breaks-your-mail/
https://wordtothewise.com/2014/05/dkim-injected-headers/